### PR TITLE
Some minor changes

### DIFF
--- a/hdr_dos.h
+++ b/hdr_dos.h
@@ -45,7 +45,7 @@ typedef struct {
 	uint16_t e_oemid;
 	uint16_t e_oeminfo;
 	uint16_t e_res2[10];
-	int32_t e_lfanew; // sizeof(IMAGE_DOS_HEADER) + size of MS-DOS stub
+	uint32_t e_lfanew; // sizeof(IMAGE_DOS_HEADER) + size of MS-DOS stub
 } IMAGE_DOS_HEADER;
 
 #pragma pack(pop)

--- a/pe.c
+++ b/pe.c
@@ -127,17 +127,12 @@ pe_err_e pe_unload(pe_ctx_t *ctx) {
 		fclose(ctx->stream);
 	}
 
-	if (ctx->path != NULL) {
-		free(ctx->path);
-	}
+	free(ctx->path);
+
 
 	// Dealloc internal pointers.
-	if (ctx->pe.directories != NULL) {
-		free(ctx->pe.directories);
-	}
-	if (ctx->pe.sections != NULL) {
-		free(ctx->pe.sections);
-	}
+	free(ctx->pe.directories);
+	free(ctx->pe.sections);
 
 	// Dealloc the virtual mapping.
 	if (ctx->map_addr != NULL) {


### PR DESCRIPTION
Since real-code stub has no size limit, I guess interpret this 32 bits as a signed int can prevent the analysis of a true binary that has this field greater than 2147483647. 

The second commit was made to close issue #7 