### PR TITLE
Fix pointer arithmetic overflow in pe_can_read()

### DIFF
--- a/pe.c
+++ b/pe.c
@@ -31,8 +31,9 @@
 #include <sys/stat.h>
 
 bool pe_can_read(const pe_ctx_t *ctx, const void *ptr, size_t size) {
-	const uintptr_t end = (uintptr_t)LIBPE_PTR_ADD(ptr, size);
-	return ptr >= ctx->map_addr && end <= ctx->map_end;
+	const uintptr_t start = (uintptr_t)ptr;
+	const uintptr_t end = start + size;
+	return start <= end && start >= (uintptr_t)ctx->map_addr && end <= (uintptr_t)ctx->map_end;
 }
 
 pe_err_e pe_load_file(pe_ctx_t *ctx, const char *path) {


### PR DESCRIPTION
This seems to be the root cause of <https://github.com/merces/pev/issues/112>.