### PR TITLE
Fixed memory leak when cleaning up cached data

### DIFF
--- a/pe.c
+++ b/pe.c
@@ -134,7 +134,8 @@ static void cleanup_cached_data(pe_ctx_t *ctx) {
 	pe_hash_sections_dealloc(ctx->cached_data.hash_sections);
 	pe_hash_dealloc(ctx->cached_data.hash_file);
 	pe_resources_dealloc(ctx->cached_data.resources);
-
+	if (ctx->cached_data.resources != NULL)
+		free(ctx->cached_data.resources);
 	memset(&ctx->cached_data, 0, sizeof(pe_cached_data_t));
 }
 

--- a/pe.c
+++ b/pe.c
@@ -134,8 +134,6 @@ static void cleanup_cached_data(pe_ctx_t *ctx) {
 	pe_hash_sections_dealloc(ctx->cached_data.hash_sections);
 	pe_hash_dealloc(ctx->cached_data.hash_file);
 	pe_resources_dealloc(ctx->cached_data.resources);
-	if (ctx->cached_data.resources != NULL)
-		free(ctx->cached_data.resources);
 	memset(&ctx->cached_data, 0, sizeof(pe_cached_data_t));
 }
 

--- a/resources.c
+++ b/resources.c
@@ -621,7 +621,5 @@ void pe_resources_dealloc(pe_resources_t *obj) {
 	if (obj == NULL)
 		return;
 	pe_resource_free_nodes(obj->root_node);
-	obj->root_node = NULL;
-	obj->resource_base_ptr = NULL;
 	free(obj);
 }

--- a/resources.c
+++ b/resources.c
@@ -623,4 +623,5 @@ void pe_resources_dealloc(pe_resources_t *obj) {
 	pe_resource_free_nodes(obj->root_node);
 	obj->root_node = NULL;
 	obj->resource_base_ptr = NULL;
+	free(obj);
 }


### PR DESCRIPTION
I've noticed a memory leak when testing peres tool.