### PR TITLE
Sort Makefile inputs to make build reproducible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ LIBNAME = libpe
 SRC_DIRS = $(srcdir) $(srcdir)/libfuzzy $(srcdir)/libudis86
 
 libpe_BUILDDIR = $(CURDIR)/build
-libpe_SRCS_FILTER = $(wildcard ${dir}/*.c)
+libpe_SRCS_FILTER = $(sort $(wildcard ${dir}/*.c))
 libpe_SRCS = $(foreach dir, ${SRC_DIRS}, ${libpe_SRCS_FILTER})
 libpe_OBJS = $(addprefix ${libpe_BUILDDIR}/, $(addsuffix .o, $(basename ${libpe_SRCS})))
 


### PR DESCRIPTION
Some Linux distributions (such as Debian [1]) are striving to make their
build reproducible.

The usage of filesystem globbing as an input to the make build might
cause inconsistencies due to differences between locales [2]. This
inconsistent behavior prevents reproducible builds.

This patch sorts the Makefile inputs to ensure they will be always
processed in the same order [3], contributing to the build system
reproducibility.

[1] https://wiki.debian.org/ReproducibleBuilds
[2] https://reproducible-builds.org/docs/stable-inputs/#fn:sorted-wildcard
[3] https://reproducible-builds.org/docs/stable-inputs/