### PR TITLE
Fix memory leak and compiler warnings

### DIFF
--- a/include/libpe/context.h
+++ b/include/libpe/context.h
@@ -1,0 +1,82 @@
+/*
+    libpe - the PE library
+
+    Copyright (C) 2010 - 2023 libpe authors
+    
+    This file is part of libpe.
+
+    libpe is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    libpe is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with libpe.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBPE_CONTEXT_H
+#define LIBPE_CONTEXT_H
+
+#include <stdio.h>
+#include <inttypes.h>
+
+#include "hdr_dos.h"
+#include "hdr_coff.h"
+#include "hdr_optional.h"
+#include "directories.h" 
+#include "sections.h"
+#include "imports.h"
+#include "exports.h"
+#include "hashes.h"
+#include "types_resources.h"
+
+typedef struct {
+	// DOS header
+	IMAGE_DOS_HEADER *dos_hdr;
+	// Signature
+	uint32_t signature;
+	// COFF header
+	IMAGE_COFF_HEADER *coff_hdr;
+	// Optional header
+	void *optional_hdr_ptr;
+	IMAGE_OPTIONAL_HEADER optional_hdr;
+	// Directories
+	uint32_t num_directories;
+	void *directories_ptr;
+	IMAGE_DATA_DIRECTORY **directories; // array up to MAX_DIRECTORIES
+	// Sections
+	uint16_t num_sections;
+	void *sections_ptr;
+	IMAGE_SECTION_HEADER **sections; // array up to MAX_SECTIONS
+	uint64_t entrypoint;
+	uint64_t imagebase;
+} pe_file_t;
+
+typedef struct {
+	// Parsed directories
+	pe_imports_t *imports;
+	pe_exports_t *exports;
+	// Hashes
+	pe_hash_headers_t *hash_headers;
+	pe_hash_sections_t *hash_sections;
+	pe_hash_t *hash_file;
+	// Resources
+	pe_resources_t *resources;
+} pe_cached_data_t;
+
+typedef struct pe_ctx {
+	FILE *stream;
+	char *path;
+	void *map_addr;
+	off_t map_size;
+	uintptr_t map_end;
+	pe_file_t pe;
+	pe_cached_data_t cached_data;
+} pe_ctx_t;
+
+#endif

--- a/include/libpe/pe.h
+++ b/include/libpe/pe.h
@@ -33,6 +33,7 @@ extern "C" {
 #include <sys/types.h>
 #include <unistd.h>
 
+#include "context.h"
 #include "error.h"
 #include "hdr_dos.h"
 #include "hdr_coff.h"
@@ -54,8 +55,8 @@ extern "C" {
 #define MAX_DLL_NAME 256
 #define MAX_FUNCTION_NAME 512
 
-#define IMAGE_ORDINAL_FLAG32 0x80000000
-#define IMAGE_ORDINAL_FLAG64 0x8000000000000000ULL
+static const uint32_t IMAGE_ORDINAL_FLAG32 = 0x80000000;
+static const uint64_t IMAGE_ORDINAL_FLAG64 = 0x8000000000000000;
 
 #define SIGNATURE_NE 0x454E // NE\0\0 in little-endian
 #define SIGNATURE_PE 0x4550 // PE\0\0 in little-endian
@@ -66,50 +67,6 @@ typedef enum {
 } pe_option_e;
 
 typedef uint16_t pe_options_e; // bitmasked pe_option_e values
-
-typedef struct {
-	// DOS header
-	IMAGE_DOS_HEADER *dos_hdr;
-	// Signature
-	uint32_t signature;
-	// COFF header
-	IMAGE_COFF_HEADER *coff_hdr;
-	// Optional header
-	void *optional_hdr_ptr;
-	IMAGE_OPTIONAL_HEADER optional_hdr;
-	// Directories
-	uint32_t num_directories;
-	void *directories_ptr;
-	IMAGE_DATA_DIRECTORY **directories; // array up to MAX_DIRECTORIES
-	// Sections
-	uint16_t num_sections;
-	void *sections_ptr;
-	IMAGE_SECTION_HEADER **sections; // array up to MAX_SECTIONS
-	uint64_t entrypoint;
-	uint64_t imagebase;
-} pe_file_t;
-
-typedef struct {
-	// Parsed directories
-	pe_imports_t *imports;
-	pe_exports_t *exports;
-	// Hashes
-	pe_hash_headers_t *hash_headers;
-	pe_hash_sections_t *hash_sections;
-	pe_hash_t *hash_file;
-	// Resources
-	pe_resources_t *resources;
-} pe_cached_data_t;
-
-typedef struct pe_ctx {
-	FILE *stream;
-	char *path;
-	void *map_addr;
-	off_t map_size;
-	uintptr_t map_end;
-	pe_file_t pe;
-	pe_cached_data_t cached_data;
-} pe_ctx_t;
 
 // General functions
 bool pe_can_read(const pe_ctx_t *ctx, const void *ptr, size_t size);

--- a/include/libpe/resources.h
+++ b/include/libpe/resources.h
@@ -24,52 +24,13 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "context.h"
 #include "error.h"
 #include "dir_resources.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-// Forward declare `pe_ctx_t` because we cannot include `pe.h` here due to circular dependency.
-struct pe_ctx;
-typedef struct pe_ctx pe_ctx_t;
-
-typedef enum {
-	LIBPE_RDT_LEVEL1 = 1,
-	LIBPE_RDT_LEVEL2 = 2,
-	LIBPE_RDT_LEVEL3 = 3
-} pe_resource_level_e;
-
-typedef enum {
-	LIBPE_RDT_RESOURCE_DIRECTORY = 1,
-	LIBPE_RDT_DIRECTORY_ENTRY = 2,
-	LIBPE_RDT_DATA_STRING = 3,
-	LIBPE_RDT_DATA_ENTRY = 4
-} pe_resource_node_type_e;
-
-typedef struct pe_resource_node {
-	uint16_t depth;
-	uint32_t dirLevel; // pe_resouces_level_e
-	pe_resource_node_type_e type;
-	char *name;
-	union {
-		void *raw_ptr; // We are allowed to rely on type-punning in C99, but not in C++.
-		IMAGE_RESOURCE_DIRECTORY *resourceDirectory; // type == LIBPE_RDT_RESOURCE_DIRECTORY
-		IMAGE_RESOURCE_DIRECTORY_ENTRY *directoryEntry; // type == LIBPE_RDT_DIRECTORY_ENTRY
-		IMAGE_RESOURCE_DATA_STRING_U *dataString; // type == LIBPE_RDT_DATA_STRING
-		IMAGE_RESOURCE_DATA_ENTRY *dataEntry; // type == LIBPE_RDT_DATA_ENTRY
-	} raw;
-	struct pe_resource_node *parentNode; // Points to the parent node, if any.
-	struct pe_resource_node *childNode; // Points to the 1st child node, if any.
-	struct pe_resource_node *nextNode; // Points to the next sibling node, if any.
-} pe_resource_node_t;
-
-typedef struct {
-	pe_err_e err;
-	void *resource_base_ptr; // A pointer to the beggining of the `IMAGE_RESOURCE_DIRECTORY`.
-	pe_resource_node_t *root_node;
-} pe_resources_t;
 
 //
 // Type Lookup for IMAGE_RESOURCE_DATA_ENTRY

--- a/include/libpe/types_resources.h
+++ b/include/libpe/types_resources.h
@@ -1,0 +1,65 @@
+/*
+    libpe - the PE library
+
+    Copyright (C) 2010 - 2023 libpe authors
+    
+    This file is part of libpe.
+
+    libpe is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    libpe is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with libpe.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBPE_TYPES_RESOURCES_H
+#define LIBPE_TYPES_RESOURCES_H
+
+#include <stdint.h>
+#include "dir_resources.h"
+#include "error.h"
+
+typedef enum {
+	LIBPE_RDT_LEVEL1 = 1,
+	LIBPE_RDT_LEVEL2 = 2,
+	LIBPE_RDT_LEVEL3 = 3
+} pe_resource_level_e;
+
+typedef enum {
+	LIBPE_RDT_RESOURCE_DIRECTORY = 1,
+	LIBPE_RDT_DIRECTORY_ENTRY = 2,
+	LIBPE_RDT_DATA_STRING = 3,
+	LIBPE_RDT_DATA_ENTRY = 4
+} pe_resource_node_type_e;
+
+typedef struct pe_resource_node {
+	uint16_t depth;
+	uint32_t dirLevel; // pe_resouces_level_e
+	pe_resource_node_type_e type;
+	char *name;
+	union {
+		void *raw_ptr; // We are allowed to rely on type-punning in C99, but not in C++.
+		IMAGE_RESOURCE_DIRECTORY *resourceDirectory; // type == LIBPE_RDT_RESOURCE_DIRECTORY
+		IMAGE_RESOURCE_DIRECTORY_ENTRY *directoryEntry; // type == LIBPE_RDT_DIRECTORY_ENTRY
+		IMAGE_RESOURCE_DATA_STRING_U *dataString; // type == LIBPE_RDT_DATA_STRING
+		IMAGE_RESOURCE_DATA_ENTRY *dataEntry; // type == LIBPE_RDT_DATA_ENTRY
+	} raw;
+	struct pe_resource_node *parentNode; // Points to the parent node, if any.
+	struct pe_resource_node *childNode; // Points to the 1st child node, if any.
+	struct pe_resource_node *nextNode; // Points to the next sibling node, if any.
+} pe_resource_node_t;
+
+typedef struct {
+	pe_err_e err;
+	void *resource_base_ptr; // A pointer to the beggining of the `IMAGE_RESOURCE_DIRECTORY`.
+	pe_resource_node_t *root_node;
+} pe_resources_t;
+
+#endif

--- a/misc.c
+++ b/misc.c
@@ -20,7 +20,9 @@
 */
 
 // for memmem() to work.
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 
 #include "libpe/pe.h"
 #include <stdlib.h>
@@ -103,9 +105,13 @@ int cpl_analysis(pe_ctx_t *ctx) {
 			| IMAGE_FILE_DLL);
 
 	// FIXME: Which timestamps are those?
-  // UNIX timestams: 
-  //    708992537 = 19/jun/1992 @ 19:22:17
-  //   1354555867 = 3/dez/2012 @ 15:31:07
+	// UNIX timestams:
+	//    708992537 = 19/jun/1992 @ 19:22:17
+	//   1354555867 =  3/dez/2012 @ 15:31:07
+	//
+	// Findings:
+	// *  708992537 is the timestamp from an old delphi compiler bug
+	// * 1354555867 was probably just the current time
 	if ((hdr_coff_ptr->TimeDateStamp == 708992537 ||
 				hdr_coff_ptr->TimeDateStamp > 1354555867)
 			&& (hdr_coff_ptr->Characteristics == characteristics1 || // equals 0xa18e


### PR DESCRIPTION
This looks bigger than it actually is. From what I can tell I have now fixed every memory leak in pev. At least with my test executable (putty.exe). None of them were major obviously but better have them fixed.
I also fixed all warnings GCC gave me (except for libudis86 stuff).

The reason why I put `pe_ctx_t` and `pe_resources_t` into their own headers is because redefinition of typedefs is technically a C11 feature. This lead to a warning every time `pe.h` was used.

Another warning I fixed is harder to explain because it is platform specific: In `hashes.c` `IMAGE_ORDINAL_FLAG64` was used as a macro with the `UL` postfix aka unsigned long. This was then (rightfully) fed into PRIu64 which is a macro to print a 64 bit integer based on the current system. This works fine under windows as under Windows an `uint64_t` is extended to `unsigned long int`. Under Linux however it extents to `unsigned long long int`. Technically both are 64 bit under Linux but it still gives a Wformat warning (I don't make the rules). Thus I have changed the macro into a `static const uint64_t`. This is more in line with what we want (specifically an unsigned 64 bit integer), it's more platform independent and as a side effect it's also more debugger friendly. The cast to `uint64_t` of the logic and result is for the same reason but should have no effect on the actual compiled library.

The rest of the warnings are more self explanatory.